### PR TITLE
Don't listen for 'vision' to reduce noise

### DIFF
--- a/scripts/benefits.js
+++ b/scripts/benefits.js
@@ -3,7 +3,7 @@ module.exports = (robot) => {
     res.send("🦷 Looking for DC37 dentists? Here's a <https://github.com/NYCPlanning/nyc-dc37-benefits-map/blob/master/dc37_dentists.geojson|map> and <https://github.com/NYCPlanning/nyc-dc37-benefits-map/blob/master/dc37_dental.csv|list> of eligible providers.");
   })
 
-  robot.hear(/optical|vision|opticians*|opthamologists*/i, async (res) => {
+  robot.hear(/optical|opticians*|opthamologists*/i, async (res) => {
     res.send("👓 Looking for DC37 opthamologists? Here's a <https://github.com/NYCPlanning/nyc-dc37-benefits-map/blob/master/dc37_optical.geojson|map> and <https://github.com/NYCPlanning/nyc-dc37-benefits-map/blob/master/dc37_optical.csv|list> of eligible providers.");
   })
 }


### PR DESCRIPTION
This PR removes "vision" from the strings that plannerbot listens to so that it doesn't send unwanted messages into slack.

Closes #12 